### PR TITLE
Update refs.bib

### DIFF
--- a/refs.bib
+++ b/refs.bib
@@ -16183,9 +16183,6 @@ issn = "1369-7412"
   pages     = {197-207},
   volume    = {27},
   doi       = {10.1016/j.ijforecast.2009.12.015},
-  owner     = {SKolassa},
-  status    = {Elektronisch},
-  timestamp = {2020.09.14},
 }
 
 @Article{GneitingRaftery2007_SK,
@@ -16321,6 +16318,19 @@ issn = "1369-7412"
   doi       = {10.1016/j.ijforecast.2019.06.004},
   timestamp = {2020.09.14},
 }
+
+@article{FildesKolassaMa-postscript,
+title = {Post-script---Retail forecasting: Research and practice},
+journal = {International Journal of Forecasting},
+year = {2021},
+issn = {0169-2070},
+doi = {https://doi.org/10.1016/j.ijforecast.2021.09.012},
+url = {https://www.sciencedirect.com/science/article/pii/S0169207021001618},
+author = {Robert Fildes and Stephan Kolassa and Shaohui Ma},
+keywords = {COVID-19, Disruption, Structural change, Instability, Omni-retailing, Online retail, Machine learning},
+abstract = {This note updates the 2019 review article ``Retail forecasting: Research and practice'' in the context of the COVID-19 pandemic and the substantial new research on machine-learning algorithms, when applied to retail. It offers new conclusions and challenges for both research and practice in retail demand forecasting.}
+}
+
 
 @Article{MelaciniPerottiRasiniEtAl2018_SK,
   author    = {Melacini, Marco and Perotti, Sara and Rasini, Monica and Tappia, Elena},
@@ -24566,19 +24576,31 @@ author = {Artemios-Anargyros Semenoglou and Evangelos Spiliotis and Spyros Makri
 }
 
 @ARTICLE{Makridakis2020-wq,
-title = "The {M5} Accuracy competition: Results, findings and conclusions",
+title = "{M5} accuracy competition: Results, findings and conclusions",
 author = "Makridakis, Spyros and Spiliotis, Evangelos and Assimakopoulos, Vassilis",
 journal={International Journal of Forecasting},
-year =  {2021}
+year =  {2022},
+doi = {https://doi.org/10.1016/j.ijforecast.2021.11.013},
 }
 
 @ARTICLE{Makridakis2020-bj,
-title = "The {M5} Uncertainty competition: Results, findings and conclusions",
-author = "Makridakis, Spyros and Spiliotis, Evangelos and Assimakopoulos, Vassilis and Chen, Zhi and Winkler, Robert L and {others}",
+title = "The {M5} uncertainty competition: Results, findings and conclusions",
+author = "Makridakis, Spyros and Spiliotis, Evangelos and Assimakopoulos, Vassilis and Chen, Zhi and Winkler, Robert L",
 journal={International Journal of Forecasting},
-year =  {2021}
+year =  {2022},
+doi = {https://doi.org/10.1016/j.ijforecast.2021.10.009}
 }
 
+@article{HOELTGEBAUM2021715,
+title = {A score-driven model of short-term demand forecasting for retail distribution centers},
+journal = {Journal of Retailing},
+volume = {97},
+number = {4},
+pages = {715-725},
+year = {2021},
+doi = {https://doi.org/10.1016/j.jretai.2021.05.003},
+author = {Henrique Hoeltgebaum and Denis Borenstein and Cristiano Fernandes and Álvaro Veiga},
+}
 
 @ARTICLE{Abouarghoub2018-wz,
 title = "On reconciling macro and micro energy transport forecasts for strategic decision making in the tanker industry",


### PR DESCRIPTION
Included FildesKolassaMa-postscript, the postscript to the Fildes et al. article on retail forecasting. Updated the two M5 papers Makridakis2020-wq and Makridakis2020-bj with current information. Added HOELTGEBAUM2021715 reference.